### PR TITLE
URL encode filenames

### DIFF
--- a/lib/til/core.rb
+++ b/lib/til/core.rb
@@ -131,14 +131,18 @@ module Til
       content
     end
 
+    def new_filename(commit_title)
+      today = Time.now.strftime '%Y-%m-%d'
+      name = (commit_title.split.map(&:downcase).join('-'))
+      "#{today}_#{name}.md"
+    end
+
     def commit_new_til(category, content)
       commit_title = content.lines[0].chomp
       if commit_title.start_with?('#')
         commit_title = commit_title[1..].strip
       end
-      today = Time.now.strftime '%Y-%m-%d'
-      name = commit_title.split.map(&:downcase).join('-')
-      filename = "#{today}_#{name}.md"
+      filename = new_filename(commit_title)
 
       ref = github_client.ref repo_name, 'heads/master'
       commit = github_client.commit repo_name, ref.object.sha

--- a/test/til_test.rb
+++ b/test/til_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'timecop'
 
 describe Til::Core do
   it 'has a run method' do
@@ -36,5 +37,18 @@ describe Til::Core do
       Til::Core.new(kernel: kernel_mock, env: { 'GH_TOKEN' => 'abc' }).run
     end
     assert_match "fzf is required, you can install it on macOS with 'brew install fzf'", error.message
+  end
+
+  it 'escapes URLs in filenames' do
+    # Yeah yeah, I'm testing a private methode, it's 'wrong', but *shrug*
+    til = Til::Core.new(
+      env: { 'GH_TOKEN' => 'abc', 'GH_REPO' => 'pjambet/til' },
+    )
+
+    Timecop.freeze(Time.local(2020, 6, 25, 12, 0, 0)) do
+      filename = til.send :new_filename, 'Ruby 2.7 adds Enumerable#filter_map'
+
+      assert_equal '2020-06-25_ruby-2.7-adds-enumerable%23filter_map.md', filename
+    end
   end
 end


### PR DESCRIPTION
The problem occured for filenames containing characters like `#`, e.g:

`Ruby 2.7 adds Enumerable#filter_map` should become `2020-06-25_ruby-2.7-adds-enumerable%23filter_map.md` and not
`2020-06-25_ruby-2.7-adds-enumerable#filter_map.md`

Turns out the `URI.encode` is deprecated, so I ended up using `CGI.escape` as recommended by [Rubocop][rubocop]

Fixes #1

[rubocop]:https://docs.rubocop.org/rubocop/0.86/cops_lint.html#linturiescapeunescape