### PR TITLE
User better environment variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Add the following variables to your environment:
 You might want to add those to either your `.bashrc` or `.zshrc` but please be careful in case you share those publicly
 as the token is private and *must not* be shared publicly.
 
+Note: An earlier version of this gem used different names, `GH_TOKEN` & `GH_REPO`, it still works, but is not the
+recommended approach anymore, see #2.
+
 ### Step 4:
 
 Run `til` from the command line

--- a/lib/til/core.rb
+++ b/lib/til/core.rb
@@ -5,6 +5,9 @@ require 'readline'
 module Til
   class Core
 
+    GH_TOKEN_ENV_VAR_NAME = 'TIL_RB_GITHUB_TOKEN'
+    GH_REPO_ENV_VAR_NAME = 'TIL_RB_GITHUB_REPO'
+
     def self.run(options: {})
       # Exit if `fzf` is not available
       # Optionally print a spinner
@@ -59,12 +62,20 @@ module Til
     end
 
     def check_environment_variables
-      if @env['GH_TOKEN'].nil? || @env['GH_TOKEN'] == ''
-        raise 'The GH_TOKEN (with the public_repo or repo scope) environment variable is required'
+      if @env[GH_TOKEN_ENV_VAR_NAME].nil? || @env[GH_TOKEN_ENV_VAR_NAME] == ''
+        if @env['GH_TOKEN'].nil? || @env['GH_TOKEN'] == ''
+          raise "The #{GH_TOKEN_ENV_VAR_NAME} (with the public_repo or repo scope) environment variable is required"
+        else
+          @stderr.puts "Using GH_TOKEN is deprecated, use #{GH_TOKEN_ENV_VAR_NAME} instead"
+        end
       end
 
-      if @env['GH_REPO'].nil? || @env['GH_REPO'] == ''
-        raise 'The GH_REPO environment variable is required'
+      if @env[GH_REPO_ENV_VAR_NAME].nil? || @env[GH_REPO_ENV_VAR_NAME] == ''
+        if @env['GH_REPO'].nil? || @env['GH_REPO'] == ''
+          raise "The #{GH_REPO_ENV_VAR_NAME} environment variable is required"
+        else
+          @stderr.puts "Using GH_REPO is deprecated, use #{GH_REPO_ENV_VAR_NAME} instead"
+        end
       end
     end
 
@@ -81,11 +92,11 @@ module Til
     end
 
     def github_client
-      @github_client ||= Octokit::Client.new(access_token: @env['GH_TOKEN'])
+      @github_client ||= Octokit::Client.new(access_token: @env[GH_TOKEN_ENV_VAR_NAME] || @env['GH_TOKEN'])
     end
 
     def repo_name
-      @repo_name ||= @env['GH_REPO']
+      @repo_name ||= (@env[GH_REPO_ENV_VAR_NAME] || @env['GH_REPO'])
     end
 
     def prompt_fzf(categories)

--- a/test/til_test.rb
+++ b/test/til_test.rb
@@ -11,30 +11,65 @@ describe Til::Core do
     Til::Core.new(
       process: Process,
       stderr: StringIO.new,
-      env: { 'GH_TOKEN' => 'abc', 'GH_REPO' => 'pjambet/til' },
+      env: { 'TIL_RB_GITHUB_TOKEN' => 'abc', 'TIL_RB_GITHUB_REPO' => 'pjambet/til' },
       github_client: github_client_mock,
     ).run
   end
 
-  it 'exits if GH_TOKEN is nil or empty' do
+  it 'exits if TIL_RB_GITHUB_TOKEN is nil or empty' do
     error = assert_raises RuntimeError do
       Til::Core.new(env: {}).run
     end
-    assert_match 'The GH_TOKEN (with the public_repo or repo scope) environment variable is required', error.message
+    assert_match 'The TIL_RB_GITHUB_TOKEN (with the public_repo or repo scope) environment variable is required',
+                 error.message
   end
 
-  it 'exits if GH_REPO is nil or empty' do
+  it 'logs a warning if the deprecated GH_TOKEN is used' do
+    Process.stubs(:spawn).returns(12)
+    github_client_mock = mock
+    github_client_mock.expects(:contents).with('a/b', { path: '' }).returns([]).once
+    stderr = StringIO.new
+
+    Til::Core.new(
+      env: { 'GH_TOKEN' => 'abc', 'TIL_RB_GITHUB_REPO' => 'a/b' },
+      stderr: stderr,
+      github_client: github_client_mock,
+    ).run
+
+    stderr.rewind
+    assert_match(/\AUsing GH_TOKEN is deprecated, use TIL_RB_GITHUB_TOKEN instead$/,
+                 stderr.read)
+  end
+
+  it 'exits if TIL_RB_GITHUB_REPO is nil or empty' do
     error = assert_raises RuntimeError do
-      Til::Core.new(env: { 'GH_TOKEN' => 'abc' }).run
+      Til::Core.new(env: { 'TIL_RB_GITHUB_TOKEN' => 'abc' }).run
     end
-    assert_match 'The GH_REPO environment variable is required', error.message
+    assert_match 'The TIL_RB_GITHUB_REPO environment variable is required', error.message
+  end
+
+  it 'logs a warning if the deprecated GH_REPO is used' do
+    Process.stubs(:spawn).returns(12)
+    github_client_mock = mock
+    github_client_mock.expects(:contents).with('a/b', { path: '' }).returns([]).once
+    stderr = StringIO.new
+
+    Til::Core.new(
+      env: { 'GH_REPO' => 'a/b', 'TIL_RB_GITHUB_TOKEN' => 'abc' },
+      stderr: stderr,
+      github_client: github_client_mock,
+    ).run
+
+    stderr.rewind
+    assert_match(/\AUsing GH_REPO is deprecated, use TIL_RB_GITHUB_REPO instead$/,
+                 stderr.read)
   end
 
   it 'exits if fzf is not available' do
     error = assert_raises RuntimeError do
       kernel_mock = Minitest::Mock.new
       kernel_mock.expect :system, false, ['which fzf', { out: '/dev/null', err: '/dev/null' }]
-      Til::Core.new(kernel: kernel_mock, env: { 'GH_TOKEN' => 'abc' }).run
+      Til::Core.new(kernel: kernel_mock, env: { 'TIL_RB_GITHUB_TOKEN' => 'abc' }).run
     end
     assert_match "fzf is required, you can install it on macOS with 'brew install fzf'", error.message
   end
@@ -42,7 +77,7 @@ describe Til::Core do
   it 'escapes URLs in filenames' do
     # Yeah yeah, I'm testing a private methode, it's 'wrong', but *shrug*
     til = Til::Core.new(
-      env: { 'GH_TOKEN' => 'abc', 'GH_REPO' => 'pjambet/til' },
+      env: { 'TIL_RB_GITHUB_TOKEN' => 'abc', 'TIL_RB_GITHUB_REPO' => 'pjambet/til' },
     )
 
     Timecop.freeze(Time.local(2020, 6, 25, 12, 0, 0)) do


### PR DESCRIPTION
As pointed out in #2, the previous names were very generic, and it might conflict with other GitHub related variables
people have in their environments.

These names are now very explicit with the `TIL_RB` prefix, and we will introduce a better way, using a file under
`~/.config` later on to remove the need for environment variables.

Fixes #2