### PR TITLE
Fix URL encoding of links

### DIFF
--- a/lib/til/core.rb
+++ b/lib/til/core.rb
@@ -144,7 +144,7 @@ module Til
 
     def new_filename(commit_title)
       today = Time.now.strftime '%Y-%m-%d'
-      name = CGI.escape(commit_title.split.map(&:downcase).join('-'))
+      name = commit_title.split.map(&:downcase).join('-')
       "#{today}_#{name}.md"
     end
 
@@ -178,8 +178,11 @@ module Til
       commit = github_client.create_commit repo_name, commit_title, tree.sha, ref.object.sha
       github_client.update_ref repo_name, 'heads/master', commit.sha
 
-      puts "You can see your new TIL at : https://github.com/#{repo_name}/blob/master/#{category}/#{filename}"
-      puts "You can edit your new TIL at : https://github.com/#{repo_name}/edit/master/#{category}/#{filename}"
+      cgi_escaped_filename = CGI.escape(filename)
+      til_url = "https://github.com/#{repo_name}/blob/master/#{category}/#{cgi_escaped_filename}"
+      til_edit_url = "https://github.com/#{repo_name}/edit/master/#{category}/#{cgi_escaped_filename}"
+      puts "You can see your new TIL at : #{til_url}"
+      puts "You can edit your new TIL at : #{til_edit_url}"
     end
 
     def update_readme_content(category, commit_title, filename, readme_content)

--- a/lib/til/readme_updater.rb
+++ b/lib/til/readme_updater.rb
@@ -17,7 +17,7 @@ module Til
       loc_in_page = @initial_content.index("### #{existing_cat[1]}")
       next_cat_location = @initial_content.index('###', loc_in_page + 1)
 
-      new_line = "- [#{item_title}](#{category}/#{filename})"
+      new_line = "- [#{item_title}](#{category}/#{CGI.escape(filename)})"
       new_readme_content = ''
       if next_cat_location
         breakpoint = next_cat_location - 2
@@ -64,7 +64,7 @@ module Til
 
       next_bound = @initial_content.index('###', current_search_index + 1)
 
-      new_line = "- [#{item_title}](#{category}/#{filename})"
+      new_line = "- [#{item_title}](#{category}/#{CGI.escape(filename)})"
 
       if next_bound
         new_readme_content = @initial_content[0..(first_dashdashdash + 2)] \

--- a/test/readme_updater_test.rb
+++ b/test/readme_updater_test.rb
@@ -64,6 +64,39 @@ describe Til::ReadmeUpdater do
       assert_equal(expected_string, updater.add_item_for_existing_category('git', 'e', '2020-06-24_e.md'))
     end
 
+    it 'works with a category that is not last and a title with url encoded characters' do
+      updater = Til::ReadmeUpdater.new(@initial_content)
+      expected_string = <<~CONTENT
+      # TIL
+
+      ---
+
+      ### Categories
+
+      * [Git](#git)
+      * [Git2](#git2)
+      * [Javascript](#javascript)
+
+      ---
+
+      ### Git
+
+      - [a](git/2020-06-16_a.md)
+      - [Ruby 2.7 adds Enumerable#filter_map](git/2020-06-25_ruby-2.7-adds-enumerable%23filter_map.md)
+
+      ### Git2
+
+      - [a](git2/2020-06-16_a.md)
+
+      ### Javascript
+
+      - [c](javascript/2020-06-21_c.md)
+      CONTENT
+
+      assert_equal(expected_string, updater.add_item_for_existing_category('git', 'Ruby 2.7 adds Enumerable#filter_map', '2020-06-25_ruby-2.7-adds-enumerable#filter_map.md'))
+    end
+
+
     it 'works with the last category' do
       updater = Til::ReadmeUpdater.new(@initial_content)
       expected_string = <<~CONTENT
@@ -134,6 +167,43 @@ describe Til::ReadmeUpdater do
 
       assert_equal(expected_string, updater.add_item_for_new_category('haskell', 'e', '2020-06-24_e.md'))
     end
+
+    it 'works with a category that is not last and a title with url encoded characters' do
+      updater = Til::ReadmeUpdater.new(@initial_content)
+      expected_string = <<~CONTENT
+      # TIL
+
+      ---
+
+      ### Categories
+
+      * [Git](#git)
+      * [Git2](#git2)
+      * [Haskell](#haskell)
+      * [Javascript](#javascript)
+
+      ---
+
+      ### Git
+
+      - [a](git/2020-06-16_a.md)
+
+      ### Git2
+
+      - [a](git2/2020-06-16_a.md)
+
+      ### Haskell
+
+      - [Ruby 2.7 adds Enumerable#filter_map](haskell/2020-06-25_ruby-2.7-adds-enumerable%23filter_map.md)
+
+      ### Javascript
+
+      - [c](javascript/2020-06-21_c.md)
+      CONTENT
+
+      assert_equal(expected_string, updater.add_item_for_new_category('haskell', 'Ruby 2.7 adds Enumerable#filter_map', '2020-06-25_ruby-2.7-adds-enumerable#filter_map.md'))
+    end
+
 
     it 'works with a category that ends up first' do
       updater = Til::ReadmeUpdater.new(@initial_content)

--- a/test/til_test.rb
+++ b/test/til_test.rb
@@ -74,7 +74,7 @@ describe Til::Core do
     assert_match "fzf is required, you can install it on macOS with 'brew install fzf'", error.message
   end
 
-  it 'escapes URLs in filenames' do
+  it 'does not escape URLs in filenames' do
     # Yeah yeah, I'm testing a private methode, it's 'wrong', but *shrug*
     til = Til::Core.new(
       env: { 'TIL_RB_GITHUB_TOKEN' => 'abc', 'TIL_RB_GITHUB_REPO' => 'pjambet/til' },
@@ -83,7 +83,7 @@ describe Til::Core do
     Timecop.freeze(Time.local(2020, 6, 25, 12, 0, 0)) do
       filename = til.send :new_filename, 'Ruby 2.7 adds Enumerable#filter_map'
 
-      assert_equal '2020-06-25_ruby-2.7-adds-enumerable%23filter_map.md', filename
+      assert_equal '2020-06-25_ruby-2.7-adds-enumerable#filter_map.md', filename
     end
   end
 end


### PR DESCRIPTION
Actually fixes #1

dc89a92a0d80f9ac9adcd7ba8874244ea5be1c48 &
a41562c96b5338a34607c802bb77df631a5b38ef were attempts at fixing #1 but were
wrong.

We do not want to always CGI escape (URL encode?) the filename, just when we
create links, which we currently do in three places:

- When adding the link in the README (turns out the code is duplicated, and we
  had to change it in two places, something else I'd like to improve). So that's
  two times here
- When we output the links before exiting